### PR TITLE
基本的なカテゴリ機能とベストアンサー機能追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -16,3 +16,8 @@
   width: 100%;
   margin-top: 900px;
 }
+
+.best-answer{
+  background-color: red;
+  color: white;
+}

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,25 @@
+class CategoriesController < ApplicationController
+  include CategoryMethods
+
+  def index
+    categories = Category.all.select(:id,:category) #全てのハッシュタグを取得
+    category_count = CategoryQuestion.all.group(:category_id).count #中間テーブルのレコードをhashtag_id毎にグループ化し、数を取得(Viewにて数を表示したいため)
+    @categories = []
+    categories.each_with_index do |category| #普通にeach doでも大丈夫です。
+      category = category.attributes #ハッシュに変換
+      category["count"] = category_count[category["id"]] #countというkeyを増やし、中間テーブルの数の情報を格納する
+        @categories << category #配列に格納
+    end
+    if @categories.length > 1
+        @categories = @categories.sort{ |a,b| b["count"] <=> a["count"]} #表示はハッシュタグが使用されている投稿の多い順にする
+    end
+  end
+
+  def show
+    category_questions = CategoryQuestion.all
+    relationship_records = category_questions.select{ |cq| cq.category_id == params[:id].to_i}.map(&:question_id) #中間テーブルの全レコードより、該当ハッシュタグIDが含まれるものを取得→post_idを配列に格納 #=> [1,3]
+    all_questions = Question.all
+    @questions = all_questions.select{ |question| relationship_records.include?(question.id)} #中間テーブルの情報が含まれるPostのレコードを取得する
+    @question_objects = creating_structures(questions: @questions,category_questions: category_questions ,categories: Category.all) #取得したレコードをハッシュに変換し、ハッシュタグを一つ一つのハッシュに格納する。
+  end
+end

--- a/app/controllers/concerns/category_methods.rb
+++ b/app/controllers/concerns/category_methods.rb
@@ -1,0 +1,64 @@
+module CategoryMethods
+  extend ActiveSupport::Concern
+
+  def extract_category(contents_question)
+    if contents_question.blank? #例外処理のため。引数が空で渡ってきた場合は処理をしない
+      return
+    end
+    # 入力された文字列の中より、＃で始まる文字列を配列にして返す
+      return contents_question.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/) #=> ["#aaa","#bbb"]
+  end
+
+  #--------------ハッシュタグ保存処理　create update アクションの中で実行----------------
+  def save_category(category_array,question_instance)
+    if category_array.blank? #ハッシュタグを付けずに投稿された時、下のメソッドを実行させないようにする。
+      return
+    end
+      category_array.uniq.map do |category|
+      # ハッシュタグは先頭の#を外し、小文字にして保存
+      cate = Category.find_or_create_by(category: category.downcase.delete('#'))
+
+        #-------中間テーブルへの保存処理--------
+      category_question = CategoryQuestion.new #中間テーブルのインスタンスを作成
+      category_question.question_id = question_instance.id
+      category_question.category_id = cate.id
+      category_question.save!
+    end
+  end
+
+  #---------ハッシュタグの情報をPostオブジェクトに含めるメソッド------------
+  def creating_structures(questions: "",category_questions: "",categories: "")
+    #引数として必要なのはPostのデータ、中間テーブルの全データ、ハッシュタグの全てのデータです。
+    #このメソッドはPostのActiveRecordインスタンスをハッシュに変換し、更に一つ一つのオブジェクトに対し、idに紐づくハッシュタグを配列として格納するメソッドです。
+    array = [] #最終戻り値用
+    questions.each do |question|
+      category = [] #中間テーブルのID情報から探したハッシュタグを格納するための配列
+        question_cate = question.attributes #ActiveRecordインスタンスをハッシュに変換 { key => val, key=> val}
+        related_category_records = category_questions.select{|cq| cq.question_id == question.id } #中間テーブルより投稿idが一致するレコードを取り出す
+        related_category_records.each do |record|
+          category << categories.detect{ |category| category.id == record.category_id } #上記レコードをもとにハッシュタグを検索し、配列に格納
+        end
+        question_cate["categories"] = category #投稿一つ一つのデータに['hashtags']のkeyを追加、そこにハッシュタグのデータを格納する
+        array << question_cate #=> [{"id"=>1, "title"=>"aaaa", "caption"=>"#aaaa", "created_at"=>Sun, 02 May 2021 15:13:42 UTC +00:00, "updated_at"=>Sun, 02 May 2021 15:13:42 UTC +00:00, "user_id"=>1, "image_id"=>"e347a197a5c2e6466db2d5b1673792c0a7b3a37460b1dea00f36b8b366a6", "hashtag"=>[#<Hashtag id: 1, name: "aaaa", created_at: "2021-05-02 15:13:42", updated_at: "2021-05-02 15:13:42">}]
+    end
+      return array
+  end
+
+  #---------ハッシュタグの情報をハッシュタグテーブルと中間テーブルから削除するメソッド------------
+  def delete_records_related_to_category(question_id)
+    relationship_records = CategoryQuestion.where(question_id: question_id) #中間テーブルのレコード
+    if relationship_records.present? #中間テーブルにレコードが保存されていれば
+      relationship_records.each do |record|
+          record.destroy #中間テーブルのレコードを削除する
+      end
+    end
+      all_categories = Category.all
+      all_related_records = CategoryQuestion.all
+      all_categories.each do |category|
+        #ハッシュタグに紐づくレコードが中間テーブルに保存されていなければ、ハッシュタグを削除する
+        if all_related_records.none?{ |record| category.id == record.category_id }
+          category.destroy
+        end
+      end
+  end
+end

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -1,4 +1,6 @@
 class QuestionAnswersController < ApplicationController
+  # include CategoryMethods
+  
   def create
     @question_answer = QuestionAnswer.new(question_answer_params)
     @question_answer.user_id = current_user.id
@@ -8,6 +10,10 @@ class QuestionAnswersController < ApplicationController
     redirect_to question_path(question_id)
   rescue StandardError
     @question = Question.find(question_id)
+    related_records = CategoryQuestion.where(question_id: @question.id).pluck(:category_id) #=> [1,2,3] idのみを配列にして返す
+    categories = Category.all
+    @categories = categories.select{|category| related_records.include?(category.id)} #hashtagテーブルより中間テーブルで取得したidのハッシュタグを取得。配列に。
+    @display_contents_question = @question.contents_question.gsub(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/,"") #実際に表示するキャプション。ハッシュタグが文字列のまま表示されてしまうので、#から始まる文字列を""に変換したものをViewにて表示
     render "questions/show", status: :unprocessable_entity
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -40,13 +40,14 @@ class QuestionsController < ApplicationController
     @question.user_id = current_user.id
     category = extract_category(@question.contents_question) #パラメーターのcaptionの中よりハッシュタグを抽出
     @question.save! #一度投稿を保存
-      flash[:notice] = "成功！"
       save_category(category,@question) #先ほど抽出したハッシュタグをハッシュタグテーブルへ、作成したpostのidとハッシュタグのidを中間テーブルへ保存
-      redirect_to("/questions/index")
+      flash[:notice] = "成功！"
+      redirect_to questions_path
 
     rescue StandardError
-      flash.now[:alert] = "失敗！"
-      render "questions/new", status: :unprocessable_entity
+      # flash.now[:alert] = "失敗！"
+        render "questions/new", status: :unprocessable_entity
+      # render new_question_path, status: :unprocessable_entity
   end
 
   def edit
@@ -107,7 +108,8 @@ class QuestionsController < ApplicationController
     @question = Question.find_by(id: params[:id]) #削除対象のレコード
     @question.destroy #投稿を削除
     delete_records_related_to_category(params[:id]) #中間テーブルとハッシュタグのレコードを削除
-    redirect_to "/questions", status: :see_other
+    flash[:notice] = "投稿を削除しました"
+    redirect_to questions_path, status: :see_other
   end
 
 private

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,4 +1,5 @@
 class QuestionsController < ApplicationController
+  include CategoryMethods
   before_action :set_question, only: [:show, :edit, :update, :destroy]
 
   def index
@@ -6,10 +7,17 @@ class QuestionsController < ApplicationController
     # @questions = current_user.questions.all
     @questions = Question.all
     @categories = Category.all
+    @category_questions = CategoryQuestion.all
+    @question_objects = creating_structures(questions: @questions,category_questions: @category_questions,categories: @categories)
   end
 
   def show
     @question_answer = QuestionAnswer.new
+    @question = Question.find(params[:id])
+    related_records = CategoryQuestion.where(question_id: @question.id).pluck(:category_id) #=> [1,2,3] idのみを配列にして返す
+    categories = Category.all
+    @categories = categories.select{|category| related_records.include?(category.id)} #hashtagテーブルより中間テーブルで取得したidのハッシュタグを取得。配列に。
+    @display_contents_question = @question.contents_question.gsub(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/,"") #実際に表示するキャプション。ハッシュタグが文字列のまま表示されてしまうので、#から始まる文字列を""に変換したものをViewにて表示
   end
 
   def new
@@ -18,12 +26,24 @@ class QuestionsController < ApplicationController
   end
 
   def create
-    @question = Question.new(question_params)
+    # @question = Question.new(question_params)
+    # @question.user_id = current_user.id
+    # @categories = Category.all
+    # @question.save!
+    #   flash[:notice] = "成功！"
+    #   redirect_to("/questions/new")
+    # rescue StandardError
+    #   flash.now[:alert] = "失敗！"
+    #   render "questions/new", status: :unprocessable_entity
+
+    @question = Question.new(question_params) #インスタンスの作成
     @question.user_id = current_user.id
-    @categories = Category.all
-    @question.save!
+    category = extract_category(@question.contents_question) #パラメーターのcaptionの中よりハッシュタグを抽出
+    @question.save! #一度投稿を保存
       flash[:notice] = "成功！"
-      redirect_to("/questions/new")
+      save_category(category,@question) #先ほど抽出したハッシュタグをハッシュタグテーブルへ、作成したpostのidとハッシュタグのidを中間テーブルへ保存
+      redirect_to("/questions/index")
+
     rescue StandardError
       flash.now[:alert] = "失敗！"
       render "questions/new", status: :unprocessable_entity
@@ -31,6 +51,7 @@ class QuestionsController < ApplicationController
 
   def edit
     @categories = Category.all
+    @question = Question.find(params[:id])
   end
 
   def update
@@ -41,17 +62,51 @@ class QuestionsController < ApplicationController
     #   # flash.now[:alert] = "失敗！"
     #   render "questions/edit", status: :unprocessable_entity
     # end
-    unless @question.user_question?(current_user) && @question.update(question_params)
+    # unless @question.user_question?(current_user) && @question.update(question_params)
+    #   render "questions/edit", status: :unprocessable_entity and return
+    # end
+
+    # flash[:notice] = "投稿内容を編集しました"
+    # redirect_to question_path(@question.id)
+    # end
+
+    # if logged_in? && @question.user_question?(current_user) && @question.update(question_params)
+    #   @question = Question.find(params[:id])
+    #   strong_paramater = question_params
+    #   delete_records_related_to_category(params[:id]) #こちらのメソッドで中間テーブルとハッシュタグのレコードを削除
+
+    #   # @question.update(question_params)
+    #   flash[:notice] = "投稿内容を編集しました"
+    #   category = extract_category(@question.contents_question) #投稿よりハッシュタグを取得
+    #   save_category(category,@question) #ハッシュタグの保存
+    #   redirect_to question_path(@question.id)
+    # else
+    #   render "questions/edit", status: :unprocessable_entity
+    # end
+
+    unless logged_in? && @question.user_question?(current_user) && @question.update(question_params)
       render "questions/edit", status: :unprocessable_entity and return
     end
 
+    @question = Question.find(params[:id])
+    strong_paramater = question_params
+    delete_records_related_to_category(params[:id]) #こちらのメソッドで中間テーブルとハッシュタグのレコードを削除
+
+    # @question.update(question_params)
     flash[:notice] = "投稿内容を編集しました"
+    category = extract_category(@question.contents_question) #投稿よりハッシュタグを取得
+    save_category(category,@question) #ハッシュタグの保存
     redirect_to question_path(@question.id)
   end
 
   def destroy
-    @question.destroy
-    flash[:notice] = "成功！"
+    # @question.destroy
+    # flash[:notice] = "成功！"
+    # redirect_to "/questions", status: :see_other
+
+    @question = Question.find_by(id: params[:id]) #削除対象のレコード
+    @question.destroy #投稿を削除
+    delete_records_related_to_category(params[:id]) #中間テーブルとハッシュタグのレコードを削除
     redirect_to "/questions", status: :see_other
   end
 
@@ -61,6 +116,7 @@ private
   end
 
   def question_params
-    params.require(:question).permit(:question_title, :contents_question, {:category_ids => []})
+    params.require(:question).permit(:question_title, :contents_question, :best_answer_id)
+      # , {:category_ids => []})
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,13 @@
 class SessionsController < ApplicationController
+  include CategoryMethods
   before_action :require_login, only: [:edit, :update, :destroy]
 
   def index
+    @questions = Question.all
+    @categories = Category.all
+    # @categories = current_user.category.all
+    @category_questions = CategoryQuestion.all
+    @question_objects = creating_structures(questions: @questions,category_questions: @category_questions,categories: @categories)
   end
 
   def create

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,7 +14,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
       log_in user
-      redirect_to root_url, notice: "ログインしました。"
+      redirect_to root_path, notice: "ログインしました。"
     else
       flash.now[:danger] = "メールアドレスかパスワードが間違っています。"
       render "new", status: :unprocessable_entity
@@ -23,6 +23,6 @@ class SessionsController < ApplicationController
 
   def destroy
     log_out if logged_in?
-    redirect_to root_url, notice: "ログアウトしました。", status: :see_other
+    redirect_to root_path, notice: "ログアウトしました。", status: :see_other
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,10 +29,10 @@ class UsersController < ApplicationController
   def update
     @user.avatar.attach(params[:user][:avatar]) if @user.avatar.blank?
     if @user.email == "guest@exapmle.com"
-      redirect_to root_url, alert: "ゲストユーザーは編集できません。"
+      redirect_to root_path, alert: "ゲストユーザーは編集できません。"
     elsif
       @user.update(user_params)
-      redirect_to user_url(@user), notice: "ユーザーアカウントを編集しました。"
+      redirect_to user_path(@user), notice: "ユーザーアカウントを編集しました。"
     else
       render "edit", status: :unprocessable_entity # rails7 から必須のオプション
     end
@@ -40,10 +40,10 @@ class UsersController < ApplicationController
 
   def destroy
     if @user.guest_user?
-      redirect_to root_url, alert: "ゲストユーザーは登録解除できません。"
+      redirect_to root_path, alert: "ゲストユーザーは登録解除できません。"
     else
       @user.destroy
-      redirect_to root_url, notice: "登録解除しました。", status: :see_other
+      redirect_to root_path, notice: "登録解除しました。", status: :see_other
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
 
   def show
     @questions = Question.all
-    @categories = Category.all
+    @categories = current_user.questions.map(&:categories).flatten
     @category_questions = CategoryQuestion.all
     @question_objects = creating_structures(questions: @questions,category_questions: @category_questions,categories: @categories)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
-before_action :set_user, only: [:show, :edit, :update, :destroy ]
+  include CategoryMethods
+  before_action :set_user, only: [:show, :edit, :update, :destroy ]
 
   def new
     @user = User.new
@@ -8,15 +9,18 @@ before_action :set_user, only: [:show, :edit, :update, :destroy ]
   def create
     @user = User.new(user_params)
     @user.avatar.attach(params[:user][:avatar])
-    if @user.save
+    @user.save!
       log_in @user
       redirect_to @user, notice: "新規登録完了しました。"
-    else
+    rescue StandardError
       render "new", status: :unprocessable_entity
-    end
   end
 
   def show
+    @questions = Question.all
+    @categories = Category.all
+    @category_questions = CategoryQuestion.all
+    @question_objects = creating_structures(questions: @questions,category_questions: @category_questions,categories: @categories)
   end
 
   def edit

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,0 +1,2 @@
+module CategoriesHelper
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -11,8 +11,12 @@ class Category < ApplicationRecord
   has_many :category_users
   has_many :users, through: :category_users
 
-  has_many :category_questions
+  has_many :category_questions, dependent: :destroy
   has_many :questions, through: :category_questions
 
-  validates :category, presence: true
+  validates :category, presence: true, uniqueness: { case_sensitive: false }
+
+  def user_category?(question)
+    question["user_id"] == current_user["id"]
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,6 +7,7 @@
 #  question_title    :string(255)      not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  best_answer_id    :bigint
 #  user_id           :bigint           not null
 #
 # Indexes
@@ -14,8 +15,8 @@
 #  index_questions_on_user_id  (user_id)
 #
 class Question < ApplicationRecord
-  has_many :question_answers
-  
+  has_many :question_answers, dependent: :destroy
+
   has_many :category_questions
   has_many :categories, through: :category_questions
 

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,11 @@
+<h2>ハッシュタグ一覧</h2>
+<% @categories.each do |category| %>
+    <%
+        name = category["category"]
+        count = category["count"]
+        id = category["id"]
+    %>
+    <p>
+        <%= link_to "##{name}(#{count})", category_path(id) %>
+    </p>
+<% end %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,0 +1,59 @@
+<h2>ハッシュタグが埋め込まれている投稿一覧</h2>
+<div style = "display: flex; flex-wrap: wrap;">
+  <% @question_objects.each_with_index do |question| %>
+    <%
+        display_contents_question = question["contents_question"].gsub(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/,"")
+    %>
+    <div style="border: 1px solid black;margin: 2%;padding: 3%;width: 25%;">
+        <%# <%= attachment_image_tag @questions[i],:image,style: 'width: 40%;' %>
+      <div style="border-bottom: 1px solid">
+        <p style="color: red">question_title</p>
+          <%= question["question_title"] %>
+      </div>
+      <div>
+        <p style="color: red">contents_question</p>
+        <p>
+          <%= display_contents_question %><br>
+          <% if question["categories"].present? %>
+            <% question["categories"].each do |category| %>
+              <%= link_to "##{category.category}", category_path(category.id) %>
+            <% end %>
+          <% end %>
+        <p>
+      </div>
+      <% if logged_in? && question["user_id"] == current_user["id"] %>
+        <%= link_to "詳細", question_path(id: question["id"]) %>
+        <%= link_to "編集", edit_question_path(id: question["id"]) %>
+        <%= link_to "削除", question_path(id: question["id"]), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+      <% else %>
+        <%= link_to "詳細", question_path(id: question["id"]) %>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+<%# <h2>投稿詳細</h2>
+<div style="border: 1px solid black;margin: 2% 0;padding: 3%;">
+    <%# <%= attachment_image_tag @question,:image,style: 'width: 40%;' %>
+    <%# <div style="border-bottom: 1px solid"> %>
+        <%# <p style="color: red">title</p> %>
+        <%# <%= @question.title %>
+    <%# </div> %>
+    <%# <div>
+        <p style="color: red">category</p>
+        <p>
+            <%= @display_category<br>
+            <% if @categories.present? %>
+                <%# <% @categories.each do |category| %>
+                    <%# <%= link_to "##{category.name}", category_path(category.id) %>
+                <%# <% end %>
+            <%# <% end %>
+        <%# <p>
+    </div>
+    <div> %>
+    <%# <%= link_to "編集", edit_question_path(id: @question.id) %>
+    <%# <%= link_to "削除", question_path(id: @question.id),method: :delete %>
+
+    <%# </div> %>
+<%# </div> %>
+

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -10,7 +10,7 @@
 
   <div>
     <%= f.label :question_title, '質問タイトル' %><br>
-    <%= f.text_field :question_title %>
+    <%= f.text_field :question_title, size:"55" %>
   </div>
   <div>
     <%= f.label :contents_question, '質問内容' %><br>

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -14,16 +14,16 @@
   </div>
   <div>
     <%= f.label :contents_question, '質問内容' %><br>
-    <%= f.text_area :contents_question %>
+    <%= f.text_area :contents_question, size:"55x12" %>
   </div>
 
-  <div class="field">
+  <%# <div class="field">
     <% @categories.each do |t| %>
-      <%= f.label t.category %>
-      <%= check_box_tag "question[category_ids][]", t.id, @question.category_ids.include?(t) %>
-      <br/>
-    <% end %>
-  </div>
+      <%# <%= f.label t.category %>
+      <%# <%= check_box_tag "question[category_ids][]", t.id, @question.category_ids.include?(t) %>
+      <%# <br/> %>
+    <%# <% end %>
+  <%# </div> %>
 
   <%= f.submit '登録' %>
 <% end %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,35 +1,67 @@
 <h1>Questions#index</h1>
 <p>Find me in app/views/questions/index.html.erb</p>
-<%= @test %><br>
-<% @questions.each do |question| %>
-    <tr>
-      <td><%= question.id %></td><br>
-      <td><%= question.question_title %></td><br>
-      <td><%= question.contents_question %></td><br>
-      <%# <td><%= question.category_ids</td><br> %>
-      <td><%= link_to '詳細', question %></td><br>
-    </tr>
-  <% end %>
-    <% @categories.each do |category| %>
-    <button class="btn btn-info"><%= category.category %></button><br>
-  <% end %>
 
   <td><%= link_to '質問を投稿する', new_question_url %></td><br>
 
-  <div>現在回答募集中の質問一覧です</div>
+  <td><%= link_to 'ハッシュタグ一覧', categories_path %></td><br>
+
+<h2>ハッシュタグが埋め込まれている投稿一覧</h2>
+<div style = "display: flex; flex-wrap: wrap;">
+  <% @question_objects.each_with_index do |question| %>
+    <%
+        display_contents_question = question["contents_question"].gsub(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/,"")
+    %>
+    <div style="border: 1px solid black;margin: 2%;padding: 3%;width: 25%;">
+      <div style="border-bottom: 1px solid">
+        <p style="color: red">question_title</p>
+        <%= question["question_title"] %>
+      </div>
+      <div>
+        <p style="color: red">contents_question</p>
+        <p>
+        <%= safe_join(display_contents_question.split("\n"),tag(:br)) %><br>
+          <% if question["categories"].present? %>
+            <% question["categories"].each do |category| %>
+              <%= link_to "##{category.category}", category_path(category.id) %>
+            <% end %>
+          <% end %>
+        <p>
+      </div>
+        <%= link_to "詳細", question_path(id: question["id"]) %>
+        <%# <%= link_to '詳細', question["question"] %>
+    </div>
+  <% end %>
+</div>
+
+<%= @test %><br>
+<% @questions.each do |question| %>
+  <tr>
+    <td><%= question.id %></td><br>
+    <td><%= question.question_title %></td><br>
+    <td><%= question.contents_question %></td><br>
+    <%# <td><%= question.category_ids</td><br> %>
+    <td><%= link_to '詳細', question %></td><br>
+  </tr>
+<% end %>
+
+<td><%= link_to '質問を投稿する', new_question_url %></td><br>
+
+<div>現在回答募集中の質問一覧です</div>
   <div class="row text-center">
     <% @questions.each do |question| %>
       <div class="col-lg-3 col-md-6 mb-4">
         <div class="card h-100">
           <img class="card-img-top" src="http://placehold.it/500x325" alt="">
-          <div class="card-body">
-            <h4 class="card-title"><%= question.question_title %></h4>
-            <p class="card-text"><%= question.contents_question %></p>
-          </div>
-          <div class="card-footer">
-            <%= link_to '回答する' %>
-          </div>
+        <div class="card-body">
+          <h4 class="card-title"><%= question.question_title %></h4>
+          <p class="card-text"><%= question.contents_question %></p>
         </div>
+        <div class="card-footer">
+          <%= link_to '回答する' %>
+        </div>
+              <div class="col-lg-1 col-md-1 ba-parent">
       </div>
-    <% end %>
-  </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -11,7 +11,7 @@
 
   <div>
     <%= f.label :question_title, '質問タイトル' %><br>
-    <%= f.text_field :question_title %>
+    <%= f.text_field :question_title, size:"55" %>
   </div>
   <div>
     <%= f.label :contents_question, '質問内容' %><br>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,12 +1,13 @@
-<%= form_with(model: @question, local: true) do |f| %>
-<% if @question.errors.any? %>
-  <strong><%= @question.errors.count %>個のエラーがあります。</strong>
-  <ul>
-    <% @question.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
+<div>
+  <%= form_with(model: @question, local: true) do |f| %>
+    <% if @question.errors.any? %>
+      <strong><%= @question.errors.count %>個のエラーがあります。</strong>
+      <ul>
+        <% @question.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
     <% end %>
-  </ul>
-<% end %>
 
   <div>
     <%= f.label :question_title, '質問タイトル' %><br>
@@ -14,16 +15,17 @@
   </div>
   <div>
     <%= f.label :contents_question, '質問内容' %><br>
-    <%= f.text_area :contents_question %>
+    <%= f.text_area :contents_question, size:"55x12" %>
   </div>
 
-  <div class="field">
-    <% @categories.each do |t| %>
-      <%= f.label t.category %>
-      <%= check_box_tag "question[category_ids][]", t.id, @question.category_ids.include?(t) %>
-      <br/>
-    <% end %>
-  </div>
+    <%# <div class="field">
+      <% @categories.each do |t| %>
+        <%# <%= f.label t.category %>
+        <%# <%= check_box_tag "question[category_ids][]", t.id, @question.category_ids.include?(t) %>
+        <%# <br/> %>
+      <%# <% end %>
+    <%# </div> %>
 
-  <%= f.submit '登録' %>
-<% end %>
+    <%= f.submit '登録' %>
+  <% end %>
+</div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -6,24 +6,37 @@
       <%= @question.question_title %>
     </div>
     <div>
-      <p style="color: red">contents_question</p>
-      <p>
+      <%# <% if @display_contents_question.present? %>
+        <p style="color: red">contents_question</p>
+        <p>
+
+<%# <%if @display_contents_question.nil? %>
+        <%# <%= @display_contents_question %>
+<%# <% else %>
+<%# <%= safe_join(@display_contents_question.split("\n"),tag(:br)) %>
+<%# <%end %>
       <%= safe_join(@display_contents_question.split("\n"),tag(:br)) %><br>
-        <% if @categories.present? %>
-          <% @categories.each do |category| %>
-            <%= link_to "##{category.category}", category_path(category.id) %>
-          <% end %>
+      <% if @categories.present? %>
+        <% @categories.each do |category| %>
+          <%= link_to "##{category.category}", category_path(category.id) %>
         <% end %>
+      <% end %>
+      <%# <% end %>
       <p>
     </div>
     <div>
       <% if logged_in? && @question.user_question?(current_user) %>
-        <%= link_to_unless @question.best_answer_id, "編集", edit_question_path(id: @question.id) %>
-        <%= link_to_unless @question.best_answer_id, "削除", question_path(id: @question.id), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+        <%# <%= link_to_unless @question.best_answer_id,  %>
+        <%=link_to "編集", edit_question_path(id: @question.id) %>
+        <%# <%= link_to_unless @question.best_answer_id,  %>
+        <%=link_to "削除", question_path(id: @question.id), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
       <% end %>
     </div>
   </div>
 
+
+<%
+=begin %>
   <p><%= @question.question_title %></p>
   <p><%= @question.contents_question %></p>
     <% @question.categories.each do |category| %>
@@ -33,6 +46,8 @@
       <%= link_to "編集", edit_question_path(@question) %>
       <%= link_to"削除", question_path(@question), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
     <% end %>
+    <%
+=end %>
 
   <div>
     <%= form_with(model: [@question, @question_answer], local: true) do |f| %>
@@ -70,7 +85,8 @@
           <%# <%= form_with(model: @question, local: true) do |f| %>
           <%= f.hidden_field :best_answer_id, value: question_answer.id %>
           <div class="actions">
-            <%= f.submit 'BA', disabled: (@question.best_answer_id.present?) %>
+            <%= f.submit 'BA' %>
+            <%# , disabled: (@question.best_answer_id.present?) %>
           </div>
           <% end %>
         <% end %>
@@ -78,7 +94,8 @@
       <!--ここまで-->
 
       <% if logged_in? && question_answer.user_answer?(current_user) %>
-        <%=link_to_unless @question.best_answer_id, "削除", question_question_answer_path(question_answer.question.id, question_answer.id), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %><br>
+        <%# <%=link_to_unless @question.best_answer_id, %>
+        <%=link_to "削除", question_question_answer_path(question_answer.question.id, question_answer.id), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %><br>
       <% end %>
     <% end %>
   </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,39 +1,84 @@
-<p><%= @question.question_title %></p>
-<p><%= @question.contents_question %></p>
-  <% @question.categories.each do |category| %>
-    <button class="btn btn-info"><%= category.category %></button><br>
-  <% end %>
-<% if @question.user_question?(current_user) %>
-<%= link_to "編集", edit_question_path(@question) %>
-<%= link_to"削除", question_path(@question), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
-<% end %>
-
-<div>
-  <%= form_with(model: [@question, @question_answer], local: true) do |f| %>
-    <% if @question_answer.errors.any? %>
-      <strong><%= @question_answer.errors.count %>個のエラーがあります。</strong>
-      <ul>
-        <% @question_answer.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    <% end %>
-
-    <div>
-      <%= f.label :answer_content, "回答" %><br>
-      <%= f.text_area :answer_content %>
+<h2>投稿詳細</h2>
+  <div style="border: 1px solid black;margin: 2% 0;padding: 3%;">
+    <%# <%= attachment_image_tag @post,:image,style: 'width: 40%;' %>
+    <div style="border-bottom: 1px solid">
+      <p style="color: red">question_title</p>
+      <%= @question.question_title %>
     </div>
-    <%= f.submit '登録'  %>
-  <% end %>
-</div>
-<hr>
-<div>
-  <% @question.question_answers.each do |question_answer| %>
-    <p><%= question_answer.answer_content %></p>
-    <%# <% binding.pry %>
-      <%# <%= link_to "編集", edit_question_question_answer_path(current_user) %>
-    <% if question_answer.user_answer?(current_user) %>
-      <%=link_to "削除", question_question_answer_path(question_answer.question.id, question_answer.id), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+    <div>
+      <p style="color: red">contents_question</p>
+      <p>
+      <%= safe_join(@display_contents_question.split("\n"),tag(:br)) %><br>
+        <% if @categories.present? %>
+          <% @categories.each do |category| %>
+            <%= link_to "##{category.category}", category_path(category.id) %>
+          <% end %>
+        <% end %>
+      <p>
+    </div>
+    <div>
+      <% if logged_in? && @question.user_question?(current_user) %>
+        <%= link_to_unless @question.best_answer_id, "編集", edit_question_path(id: @question.id) %>
+        <%= link_to_unless @question.best_answer_id, "削除", question_path(id: @question.id), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+      <% end %>
+    </div>
+  </div>
+
+  <p><%= @question.question_title %></p>
+  <p><%= @question.contents_question %></p>
+    <% @question.categories.each do |category| %>
+      <button class="btn btn-info"><%= category.category %></button><br>
     <% end %>
-  <% end %>
-</div>
+    <% if logged_in? && @question.user_question?(current_user) %>
+      <%= link_to "編集", edit_question_path(@question) %>
+      <%= link_to"削除", question_path(@question), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+    <% end %>
+
+  <div>
+    <%= form_with(model: [@question, @question_answer], local: true) do |f| %>
+      <% if @question_answer.errors.any? %>
+        <strong><%= @question_answer.errors.count %>個のエラーがあります。</strong>
+        <ul>
+          <% @question_answer.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      <% end %>
+      <% if logged_in? %>
+      <div>
+        <%= f.label :answer_content, "回答" %><br>
+        <%= f.text_area :answer_content, size:"55x5" %>
+      </div>
+        <%= f.submit '登録'  %>
+      <% end %>
+    <% end %>
+  </div>
+  <hr>
+  <div>
+    <%# <div> %>
+    <% @question.question_answers.each do |question_answer| %>
+      <%# <p><%= question_answer.answer_content</p> %>
+      <div class="card-body  <%= "best-answer" if @question.best_answer_id == question_answer.id %>">
+      <%= safe_join(question_answer.answer_content.split("\n"),tag(:br)) %>
+      <%# <% binding.pry %>
+        <%# <%= link_to "編集", edit_question_question_answer_path(current_user) %>
+      </div>
+        <!--ここから追加-->
+      <div>
+        <% if current_user.id == @question.user_id %>
+          <%= form_with(model: @question, local: true, data: {turbo_confirm: "#{question_answer.user.name}さんの回答をベストアンサーにします。この修正は変更できませんが、よろしいですか？"}) do |f| %>
+          <%# <%= form_with(model: @question, local: true) do |f| %>
+          <%= f.hidden_field :best_answer_id, value: question_answer.id %>
+          <div class="actions">
+            <%= f.submit 'BA', disabled: (@question.best_answer_id.present?) %>
+          </div>
+          <% end %>
+        <% end %>
+      </div>
+      <!--ここまで-->
+
+      <% if logged_in? && question_answer.user_answer?(current_user) %>
+        <%=link_to_unless @question.best_answer_id, "削除", question_question_answer_path(question_answer.question.id, question_answer.id), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %><br>
+      <% end %>
+    <% end %>
+  </div>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,6 +1,6 @@
 <%= render  "shared/sample_top" %>
 <% if logged_in? %>
-  <td><%= link_to '質問を投稿する', new_question_url %></td><br>
+  <td><%= link_to '質問を投稿する', new_question_path %></td><br>
 <% end %>
   <td><%= link_to 'ハッシュタグ一覧', categories_path %></td><br>
 

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,4 +1,36 @@
 <%= render  "shared/sample_top" %>
+<% if logged_in? %>
+  <td><%= link_to '質問を投稿する', new_question_url %></td><br>
+<% end %>
+  <td><%= link_to 'ハッシュタグ一覧', categories_path %></td><br>
+
+<h2>ハッシュタグが埋め込まれている投稿一覧</h2>
+<div style = "display: flex; flex-wrap: wrap;">
+  <% @question_objects.each_with_index do |question| %>
+    <%
+        display_contents_question = question["contents_question"].gsub(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/,"")
+    %>
+    <div style="border: 1px solid black;margin: 2%;padding: 3%;width: 25%;">
+      <div style="border-bottom: 1px solid">
+        <p style="color: red">question_title</p>
+        <%= question["question_title"] %>
+      </div>
+      <div>
+        <p style="color: red">contents_question</p>
+        <p>
+        <%= safe_join(display_contents_question.split("\n"),tag(:br)) %><br>
+          <% if question["categories"].present? %>
+            <% question["categories"].each do |category| %>
+              <%= link_to "##{category.category}", category_path(category.id) %>
+            <% end %>
+          <% end %>
+        <p>
+      </div>
+        <%= link_to "詳細", question_path(id: question["id"]) %>
+    </div>
+  <% end %>
+</div>
+
       <%# <p><h1>ログインできたよ</h1></p>
         <p>テスト</p>
       <p><%= link_to "Log in画面に戻る", login_path</p><br>

--- a/app/views/shared/_sample_top.html.erb
+++ b/app/views/shared/_sample_top.html.erb
@@ -4,7 +4,9 @@
         <h1 class="text-2xl font-semibold text-white uppercase lg:text-3xl">
         Build Your new <span class="text-blue-400 underline">Saas</span>
       </h1>
-      <button class="w-full px-4 py-2 mt-4 text-sm font-medium text-white uppercase transition-colors duration-200 bg-blue-600 rounded-md lg:w-auto hover:bg-blue-500 focus:outline-none focus:bg-blue-500">Start project</button>
+      <%= link_to new_question_path do %>
+      <button class="w-full px-4 py-2 mt-4 text-sm font-medium text-white uppercase transition-colors duration-200 bg-blue-600 rounded-md lg:w-auto hover:bg-blue-500 focus:outline-none focus:bg-blue-500">質問を投稿する！</button>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,27 +1,38 @@
 <h1 class="text-5xl text-green-600">＜ユーザー情報＞</h1>
-  <%if current_user%>
-    <h1>
-      <p>メールアドレス：<%= @user.email %></p>
-      <p><%="#{current_user.name}さん"%></p>
-      <%= image_tag avatar_url(current_user), width: 200, class: "rounded-lg" %>
-    </h1>
+<%if current_user%>
+  <h1>
+    <p>メールアドレス：<%= @user.email %></p>
+    <p><%="#{current_user.name}さん"%></p>
+    <%= image_tag avatar_url(current_user), width: 200, class: "rounded-lg" %>
+  </h1>
 
-    <p><% @user.questions.each do |question| %></p>
-    <%= link_to question.question_title, question_path(question) %>
-    <% end %>
+  <p><% @user.questions.each do |question| %></p>
+  <%= link_to question.question_title, question_path(question) %>
+  <% end %>
 
-    <div class="space-x-4 p-2">
-      <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete, turbo_confirm: "本当にログアウトしますか？" }, class: "w-full px-4 py-2 mt-4 text-sm font-medium text-white uppercase transition-colors duration-200 transform bg-blue-600 rounded-md lg:w-auto hover:bg-blue-500 focus:outline-none focus:bg-blue-500" %>
-    </div>
+  <h2>ハッシュタグ一覧</h2>
+  <% @categories.each do |category| %>
+      <%
+          name = category["category"]
+          id = category["id"]
+      %>
+      <p>
+          <%= link_to "currentuserのカテゴリのみ表示したい##{name}", category_path(id) %>
+      </p>
+  <% end %>
 
-    <div class="space-x-4 p-2">
-      <%= link_to '登録解除', user_path(@user.id), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "w-full px-4 py-2 mt-4 text-sm font-medium text-white uppercase transition-colors duration-200 transform bg-blue-600 rounded-md lg:w-auto hover:bg-blue-500 focus:outline-none focus:bg-blue-500" %>
-    </div>
+  <div class="space-x-4 p-2">
+    <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete, turbo_confirm: "本当にログアウトしますか？" }, class: "w-full px-4 py-2 mt-4 text-sm font-medium text-white uppercase transition-colors duration-200 transform bg-blue-600 rounded-md lg:w-auto hover:bg-blue-500 focus:outline-none focus:bg-blue-500" %>
+  </div>
 
-    <div class="space-x-4 p-2">
-      <%= link_to "設定", edit_user_path(current_user), class: "w-full px-4 py-2 mt-4 text-sm font-medium text-white uppercase transition-colors duration-200 transform bg-blue-600 rounded-md lg:w-auto hover:bg-blue-500 focus:outline-none focus:bg-blue-500" %>
-    </div>
-  <%end%>
+  <div class="space-x-4 p-2">
+    <%= link_to '登録解除', user_path(@user.id), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "w-full px-4 py-2 mt-4 text-sm font-medium text-white uppercase transition-colors duration-200 transform bg-blue-600 rounded-md lg:w-auto hover:bg-blue-500 focus:outline-none focus:bg-blue-500" %>
+  </div>
+
+  <div class="space-x-4 p-2">
+    <%= link_to "設定", edit_user_path(current_user), class: "w-full px-4 py-2 mt-4 text-sm font-medium text-white uppercase transition-colors duration-200 transform bg-blue-600 rounded-md lg:w-auto hover:bg-blue-500 focus:outline-none focus:bg-blue-500" %>
+  </div>
+<%end%>
 
 <%
 =begin %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,13 +12,9 @@
 
   <h2>ハッシュタグ一覧</h2>
   <% @categories.each do |category| %>
-      <%
-          name = category["category"]
-          id = category["id"]
-      %>
-      <p>
-          <%= link_to "currentuserのカテゴリのみ表示したい##{name}", category_path(id) %>
-      </p>
+    <p>
+      <%= link_to "##{category.category}", category_path(category.id) %>
+    </p>
   <% end %>
 
   <div class="space-x-4 p-2">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,8 +6,9 @@
     <%= image_tag avatar_url(current_user), width: 200, class: "rounded-lg" %>
   </h1>
 
+  <h2>質問投稿一覧</h2>
   <p><% @user.questions.each do |question| %></p>
-  <%= link_to question.question_title, question_path(question) %>
+    <%= link_to question.question_title, question_path(question) %>
   <% end %>
 
   <h2>ハッシュタグ一覧</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
     resources :question_answers, only: [:create, :destroy, :edit, :update]
   end
 
+  resources :categories, only: [:index, :show] #hashtagsコントローラー作成後記入
+
   root 'sessions#index'
 
   post "/guest_login", to: "guest_sessions#create"

--- a/db/migrate/20230412045444_add_best_answer_id_to_questions.rb
+++ b/db/migrate/20230412045444_add_best_answer_id_to_questions.rb
@@ -1,0 +1,5 @@
+class AddBestAnswerIdToQuestions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :questions, :best_answer_id, :bigint, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_18_051220) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_12_045444) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -114,6 +114,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_18_051220) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "best_answer_id"
     t.index ["user_id"], name: "index_questions_on_user_id"
   end
 


### PR DESCRIPTION
本日ミーティングまでの変更点は下記となっておりますので、
念の為共有させていただきました。

・質問作成時のカテゴリ追加機能
※問題点として、
同じカテゴリを追加しようとしてもバリデーションがかからず作成できてしまう、→→  作成後詳細を見ると、同じカテゴリは非表示になっている。→→  編集しようとテキストエリアを確認すると非表示になっていたカテゴリが表示されている。
のような動作になっておりますが、ツイッターでも同じハッシュタグを作成できてしまうため、今回は重要度としましては低めに設定しております。

・ベストアンサー機能
※ベストアンサーを実行後、投稿の編集、コメントの削除ができないように設定しております。

基本的なカテゴリ、ベストアンサー機能を実装しましたが、
現状としましては、マイページでカレントユーザーのカテゴリのみを表示させようとしても、すべてのカテゴリが表示される問題に取り組んでおります。
また、先程発覚したのですが、回答欄を空欄にして作成しようとするとバリデーションがかからずエラーが発生するためそちらも対応中となっております。
